### PR TITLE
Fix typo: Heap Pump → Heat Pump

### DIFF
--- a/EI1_must_know.md
+++ b/EI1_must_know.md
@@ -382,7 +382,7 @@ $$
 
 _It is impossible to build a cyclically operating chiller whose exclusive effect is to completely transmit a certain heat quantity from a single colder reservoir to a warmer reservoir._
 
-### Heap Pump
+### Heat Pump
 
 $$
 \epsilon_{HP} = \frac{|Q_w|}{W}


### PR DESCRIPTION
I don't think you mean the [heap segment of a binary](https://en.wikipedia.org/wiki/Data_segment#Heap) nor the [heap data structure](https://en.wikipedia.org/wiki/Heap_(data_structure)) here, but a [heat pump](https://en.wikipedia.org/wiki/Heat_pump) instead.